### PR TITLE
add BCrypt password encoding with plain-text migration

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -75,6 +75,10 @@
 			<artifactId>dotenv-java</artifactId>
 			<version>3.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+		</dependency>
 
 <dependency>
     <groupId>io.jsonwebtoken</groupId>

--- a/app/src/main/java/com/project/back_end/config/SecurityConfig.java
+++ b/app/src/main/java/com/project/back_end/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.project.back_end.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/app/src/main/java/com/project/back_end/services/DoctorService.java
+++ b/app/src/main/java/com/project/back_end/services/DoctorService.java
@@ -10,6 +10,7 @@ import com.project.back_end.models.Appointment;
 import com.project.back_end.models.Doctor;
 import com.project.back_end.repo.AppointmentRepository;
 import com.project.back_end.repo.DoctorRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.transaction.Transactional;
 
@@ -17,10 +18,13 @@ import jakarta.transaction.Transactional;
 public class DoctorService {
   private final DoctorRepository doctorRepository;
   private final AppointmentRepository appointmentRepository;
+  private final PasswordEncoder passwordEncoder;
 
-  public DoctorService(DoctorRepository doctorRepository, AppointmentRepository appointmentRepository) {
+  public DoctorService(DoctorRepository doctorRepository, AppointmentRepository appointmentRepository,
+                       PasswordEncoder passwordEncoder) {
     this.doctorRepository = doctorRepository;
     this.appointmentRepository = appointmentRepository;
+    this.passwordEncoder = passwordEncoder;
   }
 
   @Transactional
@@ -52,6 +56,7 @@ public class DoctorService {
       if (doctorRepository.findByEmail(doctor.getEmail()) != null) {
         return -1;
       }
+      doctor.setPassword(passwordEncoder.encode(doctor.getPassword()));
       doctorRepository.save(doctor);
       return 1;
     } catch (Exception e) {
@@ -62,8 +67,13 @@ public class DoctorService {
 
   public int updateDoctor(Doctor doctor) {
     try {
-      if (!doctorRepository.existsById(doctor.getId())) {
-        return -1;
+      Doctor existing = doctorRepository.findById(doctor.getId()).orElse(null);
+      if (existing == null) return -1;
+      if (doctor.getPassword() != null && !doctor.getPassword().isBlank()) {
+        doctor.setPassword(passwordEncoder.encode(doctor.getPassword()));
+      } else {
+        // preserve the existing hash when no new password is provided
+        doctor.setPassword(existing.getPassword());
       }
       doctorRepository.save(doctor);
       return 1;

--- a/app/src/main/java/com/project/back_end/services/PatientService.java
+++ b/app/src/main/java/com/project/back_end/services/PatientService.java
@@ -9,6 +9,7 @@ import com.project.back_end.exceptions.InvalidTokenException;
 import com.project.back_end.exceptions.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.back_end.DTO.AppointmentDTO;
@@ -22,15 +23,19 @@ public class PatientService {
     private final PatientRepository patientRepository;
     private final AppointmentRepository appointmentRepository;
     private final TokenService tokenService;
+    private final PasswordEncoder passwordEncoder;
 
-    public PatientService(PatientRepository patientRepository, AppointmentRepository appointmentRepository, TokenService tokenService) {
+    public PatientService(PatientRepository patientRepository, AppointmentRepository appointmentRepository,
+                          TokenService tokenService, PasswordEncoder passwordEncoder) {
         this.patientRepository = patientRepository;
         this.appointmentRepository = appointmentRepository;
         this.tokenService = tokenService;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public int createPatient(Patient patient) {
         try {
+            patient.setPassword(passwordEncoder.encode(patient.getPassword()));
             patientRepository.save(patient);
             return 1;
         } catch (Exception e) {

--- a/app/src/main/java/com/project/back_end/services/ValidationService.java
+++ b/app/src/main/java/com/project/back_end/services/ValidationService.java
@@ -8,6 +8,7 @@ import com.project.back_end.models.Patient;
 import com.project.back_end.repo.AdminRepository;
 import com.project.back_end.repo.DoctorRepository;
 import com.project.back_end.repo.PatientRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -19,12 +20,16 @@ public class ValidationService {
     private final PatientRepository patientRepository;
     private final AdminRepository adminRepository;
     private final DoctorRepository doctorRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public ValidationService(TokenService tokenService, PatientRepository patientRepository, AdminRepository adminRepository, DoctorRepository doctorRepository) {
+    public ValidationService(TokenService tokenService, PatientRepository patientRepository,
+                             AdminRepository adminRepository, DoctorRepository doctorRepository,
+                             PasswordEncoder passwordEncoder) {
         this.tokenService = tokenService;
         this.patientRepository = patientRepository;
         this.adminRepository = adminRepository;
         this.doctorRepository = doctorRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     ///  Validate token
@@ -34,34 +39,58 @@ public class ValidationService {
         if(!isValid) throw new InvalidTokenException("Invalid token");
     }
 
-    ///  Validate if patient exists
     public boolean validatePatient(String email, String phone) {
         return patientRepository.findByEmailOrPhone(email, phone) == null;
     }
 
-    /// Validates patient credentials
     public String validatePatientLogin(String email, String password) {
-        Optional<Patient> patient = patientRepository.findByEmail(email);
+        Optional<Patient> opt = patientRepository.findByEmail(email);
+        if (opt.isEmpty()) throw new InvalidCredentialsException("Invalid email or password");
 
-        if (patient.isEmpty() || !patient.get().getPassword().equals(password)) {
+        Patient patient = opt.get();
+        String stored = patient.getPassword();
+
+        if (passwordEncoder.matches(password, stored)) {
+            // already BCrypt-hashed
+        } else if (password.equals(stored)) {
+            // plain-text legacy password — migrate to BCrypt on successful login
+            patient.setPassword(passwordEncoder.encode(password));
+            patientRepository.save(patient);
+        } else {
             throw new InvalidCredentialsException("Invalid email or password");
         }
-        return tokenService.generateToken(patient.get().getEmail());
+        return tokenService.generateToken(patient.getEmail());
     }
 
-    /// Validates admin credentials
-    public String validateAdminLogin(String username, String password){
+    public String validateAdminLogin(String username, String password) {
         Admin admin = adminRepository.findByUsername(username);
-        if(admin == null || !admin.getPassword().equals(password)){
+        if (admin == null) throw new InvalidCredentialsException("Invalid username or password");
+
+        String stored = admin.getPassword();
+
+        if (passwordEncoder.matches(password, stored)) {
+            // already BCrypt-hashed
+        } else if (password.equals(stored)) {
+            admin.setPassword(passwordEncoder.encode(password));
+            adminRepository.save(admin);
+        } else {
             throw new InvalidCredentialsException("Invalid username or password");
         }
         return tokenService.generateToken(admin.getUsername());
     }
 
-    /// Validates doctor credentials
-    public String validateDoctorLogin(String email, String password){
+    public String validateDoctorLogin(String email, String password) {
         Doctor doctor = doctorRepository.findByEmail(email);
-        if(doctor == null || !doctor.getPassword().equals(password)){
+        if (doctor == null) throw new InvalidCredentialsException("Invalid email or password");
+
+        String stored = doctor.getPassword();
+
+        if (passwordEncoder.matches(password, stored)) {
+            // already BCrypt-hashed
+        } else if (password.equals(stored)) {
+            doctor.setPassword(passwordEncoder.encode(password));
+            doctorRepository.save(doctor);
+        } else {
             throw new InvalidCredentialsException("Invalid email or password");
         }
         return tokenService.generateToken(doctor.getEmail());


### PR DESCRIPTION
- Add spring-security-crypto dependency and PasswordEncoder bean
- Hash passwords on patient registration and doctor create/update
- Replace plain-text equals checks with passwordEncoder.matches()
- Auto-migrate legacy plain-text passwords to BCrypt on first login